### PR TITLE
Fix fix-width fonts by fixing the manifest so things are fixed

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,6 +8,7 @@
     "porkchat.js",
     "inject.js",
     "ponies.css",
+    "fixed-width.css",
     "dark.css",
     "global.css",
     "icon_128.png",


### PR DESCRIPTION
Related error: Denying load of chrome-extension://genlcflidccakbiodbnmjnflfnbkmeip/fixed-width.css. Resources must be listed in the web_accessible_resources manifest key in order to be loaded by pages outside the extension.
